### PR TITLE
Use Control Group v2

### DIFF
--- a/package/runc/0001-Separate-Device-handling-for-default-AllowDevices.patch
+++ b/package/runc/0001-Separate-Device-handling-for-default-AllowDevices.patch
@@ -1,0 +1,268 @@
+From 410089ea4bb8bf051a941febd087b0346b967a10 Mon Sep 17 00:00:00 2001
+Message-Id: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Thu, 3 Mar 2022 14:24:37 +0100
+Subject: [PATCH 01/11] Separate Device handling for default AllowDevices
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ libcontainer/devices/device.go           |  3 +
+ libcontainer/specconv/spec_linux.go      | 96 ++++++++++++++++--------
+ libcontainer/specconv/spec_linux_test.go |  8 +-
+ 3 files changed, 70 insertions(+), 37 deletions(-)
+
+diff --git a/libcontainer/devices/device.go b/libcontainer/devices/device.go
+index c2c2b3bb..9540a89c 100644
+--- a/libcontainer/devices/device.go
++++ b/libcontainer/devices/device.go
+@@ -24,6 +24,9 @@ type Device struct {
+ 
+ 	// Gid of the device.
+ 	Gid uint32 `json:"gid"`
++
++	// Is Default Device
++	IsDefault bool `json:"is_default"`
+ }
+ 
+ // Permissions is a cgroupv1-style string to represent device access. It
+diff --git a/libcontainer/specconv/spec_linux.go b/libcontainer/specconv/spec_linux.go
+index c7ca4c8a..8bf0aa20 100644
+--- a/libcontainer/specconv/spec_linux.go
++++ b/libcontainer/specconv/spec_linux.go
+@@ -191,6 +191,7 @@ func KnownMountOptions() []string {
+ var AllowedDevices = []*devices.Device{
+ 	// allow mknod for any device
+ 	{
++		IsDefault: true,
+ 		Rule: devices.Rule{
+ 			Type:        devices.CharDevice,
+ 			Major:       devices.Wildcard,
+@@ -200,6 +201,7 @@ var AllowedDevices = []*devices.Device{
+ 		},
+ 	},
+ 	{
++		IsDefault: true,
+ 		Rule: devices.Rule{
+ 			Type:        devices.BlockDevice,
+ 			Major:       devices.Wildcard,
+@@ -209,10 +211,11 @@ var AllowedDevices = []*devices.Device{
+ 		},
+ 	},
+ 	{
+-		Path:     "/dev/null",
+-		FileMode: 0o666,
+-		Uid:      0,
+-		Gid:      0,
++		Path:      "/dev/null",
++		FileMode:  0o666,
++		Uid:       0,
++		Gid:       0,
++		IsDefault: true,
+ 		Rule: devices.Rule{
+ 			Type:        devices.CharDevice,
+ 			Major:       1,
+@@ -222,10 +225,11 @@ var AllowedDevices = []*devices.Device{
+ 		},
+ 	},
+ 	{
+-		Path:     "/dev/random",
+-		FileMode: 0o666,
+-		Uid:      0,
+-		Gid:      0,
++		Path:      "/dev/random",
++		FileMode:  0o666,
++		Uid:       0,
++		Gid:       0,
++		IsDefault: true,
+ 		Rule: devices.Rule{
+ 			Type:        devices.CharDevice,
+ 			Major:       1,
+@@ -235,10 +239,11 @@ var AllowedDevices = []*devices.Device{
+ 		},
+ 	},
+ 	{
+-		Path:     "/dev/full",
+-		FileMode: 0o666,
+-		Uid:      0,
+-		Gid:      0,
++		Path:      "/dev/full",
++		FileMode:  0o666,
++		Uid:       0,
++		Gid:       0,
++		IsDefault: true,
+ 		Rule: devices.Rule{
+ 			Type:        devices.CharDevice,
+ 			Major:       1,
+@@ -248,10 +253,11 @@ var AllowedDevices = []*devices.Device{
+ 		},
+ 	},
+ 	{
+-		Path:     "/dev/tty",
+-		FileMode: 0o666,
+-		Uid:      0,
+-		Gid:      0,
++		Path:      "/dev/tty",
++		FileMode:  0o666,
++		Uid:       0,
++		Gid:       0,
++		IsDefault: true,
+ 		Rule: devices.Rule{
+ 			Type:        devices.CharDevice,
+ 			Major:       5,
+@@ -261,10 +267,11 @@ var AllowedDevices = []*devices.Device{
+ 		},
+ 	},
+ 	{
+-		Path:     "/dev/zero",
+-		FileMode: 0o666,
+-		Uid:      0,
+-		Gid:      0,
++		Path:      "/dev/zero",
++		FileMode:  0o666,
++		Uid:       0,
++		Gid:       0,
++		IsDefault: true,
+ 		Rule: devices.Rule{
+ 			Type:        devices.CharDevice,
+ 			Major:       1,
+@@ -274,10 +281,11 @@ var AllowedDevices = []*devices.Device{
+ 		},
+ 	},
+ 	{
+-		Path:     "/dev/urandom",
+-		FileMode: 0o666,
+-		Uid:      0,
+-		Gid:      0,
++		Path:      "/dev/urandom",
++		FileMode:  0o666,
++		Uid:       0,
++		Gid:       0,
++		IsDefault: true,
+ 		Rule: devices.Rule{
+ 			Type:        devices.CharDevice,
+ 			Major:       1,
+@@ -288,6 +296,7 @@ var AllowedDevices = []*devices.Device{
+ 	},
+ 	// /dev/pts/ - pts namespaces are "coming soon"
+ 	{
++		IsDefault: true,
+ 		Rule: devices.Rule{
+ 			Type:        devices.CharDevice,
+ 			Major:       136,
+@@ -297,6 +306,7 @@ var AllowedDevices = []*devices.Device{
+ 		},
+ 	},
+ 	{
++		IsDefault: true,
+ 		Rule: devices.Rule{
+ 			Type:        devices.CharDevice,
+ 			Major:       5,
+@@ -370,12 +380,14 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
+ 		config.Mounts = append(config.Mounts, cm)
+ 	}
+ 
+-	defaultDevs, err := createDevices(spec, config)
++	err = createDevices(spec, config)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+ 
+-	c, err := CreateCgroupConfig(opts, defaultDevs)
++	defaultAllowedDevices := createDefaultDevicesCgroups(config)
++
++	c, err := CreateCgroupConfig(opts, defaultAllowedDevices)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+@@ -865,21 +877,22 @@ func stringToDeviceRune(s string) (devices.Type, error) {
+ 	}
+ }
+ 
+-func createDevices(spec *specs.Spec, config *configs.Config) ([]*devices.Device, error) {
++func createDevices(spec *specs.Spec, config *configs.Config) error {
+ 	// If a spec device is redundant with a default device, remove that default
+ 	// device (the spec one takes priority).
+-	dedupedAllowDevs := []*devices.Device{}
+-
+ next:
+ 	for _, ad := range AllowedDevices {
+-		if ad.Path != "" && spec.Linux != nil {
++		if ad.Path == "" {
++			continue next
++		}
++
++		if spec.Linux != nil {
+ 			for _, sd := range spec.Linux.Devices {
+ 				if sd.Path == ad.Path {
+ 					continue next
+ 				}
+ 			}
+ 		}
+-		dedupedAllowDevs = append(dedupedAllowDevs, ad)
+ 		if ad.Path != "" {
+ 			config.Devices = append(config.Devices, ad)
+ 		}
+@@ -899,7 +912,7 @@ next:
+ 			}
+ 			dt, err := stringToDeviceRune(d.Type)
+ 			if err != nil {
+-				return nil, err
++				return err
+ 			}
+ 			if d.FileMode != nil {
+ 				filemode = *d.FileMode &^ unix.S_IFMT
+@@ -919,7 +932,24 @@ next:
+ 		}
+ 	}
+ 
+-	return dedupedAllowDevs, nil
++	return nil
++}
++
++func createDefaultDevicesCgroups(config *configs.Config) []*devices.Device {
++	defaultAllowedDevices := []*devices.Device{}
++next:
++	for _, ad := range AllowedDevices {
++		if ad.Path != "" {
++			for _, device := range config.Devices {
++				if ad.Path == device.Path && !device.IsDefault {
++					continue next
++				}
++			}
++		}
++		defaultAllowedDevices = append(defaultAllowedDevices, ad)
++	}
++
++	return defaultAllowedDevices
+ }
+ 
+ func setupUserNamespace(spec *specs.Spec, config *configs.Config) error {
+diff --git a/libcontainer/specconv/spec_linux_test.go b/libcontainer/specconv/spec_linux_test.go
+index 56d80869..da7fa1b5 100644
+--- a/libcontainer/specconv/spec_linux_test.go
++++ b/libcontainer/specconv/spec_linux_test.go
+@@ -840,17 +840,17 @@ func TestCreateDevices(t *testing.T) {
+ 
+ 	conf := &configs.Config{}
+ 
+-	defaultDevs, err := createDevices(spec, conf)
++	err := createDevices(spec, conf)
+ 	if err != nil {
+ 		t.Errorf("failed to create devices: %v", err)
+ 	}
+ 
+-	// Verify the returned default devices has the /dev/tty entry deduplicated
++	// Verify the returned devices has the /dev/tty entry deduplicated
+ 	found := false
+-	for _, d := range defaultDevs {
++	for _, d := range conf.Devices {
+ 		if d.Path == "/dev/tty" {
+ 			if found {
+-				t.Errorf("createDevices failed: returned a duplicated device entry: %v", defaultDevs)
++				t.Errorf("createDevices failed: returned a duplicated device entry: %v", conf.Devices)
+ 			}
+ 			found = true
+ 		}
+-- 
+2.37.1
+

--- a/package/runc/0002-Implement-common-function-to-create-DeviceCgroup-rul.patch
+++ b/package/runc/0002-Implement-common-function-to-create-DeviceCgroup-rul.patch
@@ -1,0 +1,95 @@
+From c3c41d192aadac058415238e1680dffbd5a74dc6 Mon Sep 17 00:00:00 2001
+Message-Id: <c3c41d192aadac058415238e1680dffbd5a74dc6.1659958805.git.stefan@agner.ch>
+In-Reply-To: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+References: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Thu, 3 Mar 2022 14:55:53 +0100
+Subject: [PATCH 02/11] Implement common function to create DeviceCgroup rules
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ libcontainer/specconv/spec_linux.go | 52 ++++++++++++++++++++++++++---
+ 1 file changed, 48 insertions(+), 4 deletions(-)
+
+diff --git a/libcontainer/specconv/spec_linux.go b/libcontainer/specconv/spec_linux.go
+index 8bf0aa20..c5b32b1e 100644
+--- a/libcontainer/specconv/spec_linux.go
++++ b/libcontainer/specconv/spec_linux.go
+@@ -625,6 +625,48 @@ func initSystemdProps(spec *specs.Spec) ([]systemdDbus.Property, error) {
+ 	return sp, nil
+ }
+ 
++func CreateCgroupDeviceConfig(r *configs.Resources, specr *specs.LinuxResources, defaultDevs []*devices.Device) error {
++	if specr != nil {
++		for i, d := range specr.Devices {
++			var (
++				t     = "a"
++				major = int64(-1)
++				minor = int64(-1)
++			)
++			if d.Type != "" {
++				t = d.Type
++			}
++			if d.Major != nil {
++				major = *d.Major
++			}
++			if d.Minor != nil {
++				minor = *d.Minor
++			}
++			if d.Access == "" {
++				return fmt.Errorf("device access at %d field cannot be empty", i)
++			}
++			dt, err := stringToCgroupDeviceRune(t)
++			if err != nil {
++				return err
++			}
++			r.Devices = append(r.Devices, &devices.Rule{
++				Type:        dt,
++				Major:       major,
++				Minor:       minor,
++				Permissions: devices.Permissions(d.Access),
++				Allow:       d.Allow,
++			})
++		}
++	}
++
++	// Append the default allowed devices to the end of the list.
++	for _, device := range defaultDevs {
++		r.Devices = append(r.Devices, &device.Rule)
++	}
++
++	return nil
++}
++
+ func CreateCgroupConfig(opts *CreateOpts, defaultDevs []*devices.Device) (*configs.Cgroup, error) {
+ 	var (
+ 		myCgroupPath string
+@@ -681,8 +723,9 @@ func CreateCgroupConfig(opts *CreateOpts, defaultDevs []*devices.Device) (*confi
+ 
+ 	// In rootless containers, any attempt to make cgroup changes is likely to fail.
+ 	// libcontainer will validate this but ignores the error.
++	var r *specs.LinuxResources = nil
+ 	if spec.Linux != nil {
+-		r := spec.Linux.Resources
++		r = spec.Linux.Resources
+ 		if r != nil {
+ 			for i, d := range spec.Linux.Resources.Devices {
+ 				var (
+@@ -844,10 +887,11 @@ func CreateCgroupConfig(opts *CreateOpts, defaultDevs []*devices.Device) (*confi
+ 		}
+ 	}
+ 
+-	// Append the default allowed devices to the end of the list.
+-	for _, device := range defaultDevs {
+-		c.Resources.Devices = append(c.Resources.Devices, &device.Rule)
++	err := CreateCgroupDeviceConfig(c.Resources, r, defaultDevs)
++	if err != nil {
++		return nil, err
+ 	}
++
+ 	return c, nil
+ }
+ 
+-- 
+2.37.1
+

--- a/package/runc/0003-Implement-Device-Resources-updates.patch
+++ b/package/runc/0003-Implement-Device-Resources-updates.patch
@@ -1,0 +1,92 @@
+From 0f7ec1274b90032ca0383ec7c6385af1aa98b284 Mon Sep 17 00:00:00 2001
+Message-Id: <0f7ec1274b90032ca0383ec7c6385af1aa98b284.1659958805.git.stefan@agner.ch>
+In-Reply-To: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+References: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Thu, 3 Mar 2022 15:43:10 +0100
+Subject: [PATCH 03/11] Implement Device Resources updates
+
+Add support to update Device Resources with runc update.
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ libcontainer/specconv/spec_linux.go |  4 ++--
+ update.go                           | 26 +++++++++++++++++++-------
+ 2 files changed, 21 insertions(+), 9 deletions(-)
+
+diff --git a/libcontainer/specconv/spec_linux.go b/libcontainer/specconv/spec_linux.go
+index c5b32b1e..555c39ca 100644
+--- a/libcontainer/specconv/spec_linux.go
++++ b/libcontainer/specconv/spec_linux.go
+@@ -385,7 +385,7 @@ func CreateLibcontainerConfig(opts *CreateOpts) (*configs.Config, error) {
+ 		return nil, err
+ 	}
+ 
+-	defaultAllowedDevices := createDefaultDevicesCgroups(config)
++	defaultAllowedDevices := CreateDefaultDevicesCgroups(config)
+ 
+ 	c, err := CreateCgroupConfig(opts, defaultAllowedDevices)
+ 	if err != nil {
+@@ -979,7 +979,7 @@ next:
+ 	return nil
+ }
+ 
+-func createDefaultDevicesCgroups(config *configs.Config) []*devices.Device {
++func CreateDefaultDevicesCgroups(config *configs.Config) []*devices.Device {
+ 	defaultAllowedDevices := []*devices.Device{}
+ next:
+ 	for _, ad := range AllowedDevices {
+diff --git a/update.go b/update.go
+index d02e7af9..9332515c 100644
+--- a/update.go
++++ b/update.go
+@@ -8,6 +8,7 @@ import (
+ 	"strconv"
+ 
+ 	"github.com/opencontainers/runc/libcontainer/cgroups"
++	"github.com/opencontainers/runc/libcontainer/specconv"
+ 	"github.com/sirupsen/logrus"
+ 
+ 	"github.com/docker/go-units"
+@@ -298,6 +299,24 @@ other options are ignored.
+ 		config.Cgroups.Resources.PidsLimit = r.Pids.Limit
+ 		config.Cgroups.Resources.Unified = r.Unified
+ 
++		if len(r.Devices) > 0 {
++			config.Cgroups.Resources.Devices = nil
++			defaultAllowedDevices := specconv.CreateDefaultDevicesCgroups(&config)
++
++			err = specconv.CreateCgroupDeviceConfig(config.Cgroups.Resources, &r, defaultAllowedDevices)
++			if err != nil {
++				return err
++			}
++			config.Cgroups.SkipDevices = false
++		} else {
++			// If "runc update" is not changing device configuration, add
++			// this to skip device update.
++			// This helps in case an extra plugin (nvidia GPU) applies some
++			// configuration on top of what runc does.
++			// Note this field is not saved into container's state.json.
++			config.Cgroups.SkipDevices = true
++		}
++
+ 		// Update Intel RDT
+ 		l3CacheSchema := context.String("l3-cache-schema")
+ 		memBwSchema := context.String("mem-bw-schema")
+@@ -329,13 +348,6 @@ other options are ignored.
+ 			config.IntelRdt.MemBwSchema = memBwSchema
+ 		}
+ 
+-		// XXX(kolyshkin@): currently "runc update" is unable to change
+-		// device configuration, so add this to skip device update.
+-		// This helps in case an extra plugin (nvidia GPU) applies some
+-		// configuration on top of what runc does.
+-		// Note this field is not saved into container's state.json.
+-		config.Cgroups.SkipDevices = true
+-
+ 		return container.Set(config)
+ 	},
+ }
+-- 
+2.37.1
+

--- a/package/runc/0004-Adress-linter-error.patch
+++ b/package/runc/0004-Adress-linter-error.patch
@@ -1,0 +1,29 @@
+From 41724557c12e4cba5110a3b260a4340db3fe48e1 Mon Sep 17 00:00:00 2001
+Message-Id: <41724557c12e4cba5110a3b260a4340db3fe48e1.1659958805.git.stefan@agner.ch>
+In-Reply-To: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+References: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Thu, 3 Mar 2022 15:59:27 +0100
+Subject: [PATCH 04/11] Adress linter error
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ libcontainer/specconv/spec_linux.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libcontainer/specconv/spec_linux.go b/libcontainer/specconv/spec_linux.go
+index 555c39ca..d51ac5c5 100644
+--- a/libcontainer/specconv/spec_linux.go
++++ b/libcontainer/specconv/spec_linux.go
+@@ -723,7 +723,7 @@ func CreateCgroupConfig(opts *CreateOpts, defaultDevs []*devices.Device) (*confi
+ 
+ 	// In rootless containers, any attempt to make cgroup changes is likely to fail.
+ 	// libcontainer will validate this but ignores the error.
+-	var r *specs.LinuxResources = nil
++	var r *specs.LinuxResources
+ 	if spec.Linux != nil {
+ 		r = spec.Linux.Resources
+ 		if r != nil {
+-- 
+2.37.1
+

--- a/package/runc/0005-Don-t-store-is_default-in-json.patch
+++ b/package/runc/0005-Don-t-store-is_default-in-json.patch
@@ -1,0 +1,29 @@
+From d3addfe581317c208103892bb84ca816d8aadaab Mon Sep 17 00:00:00 2001
+Message-Id: <d3addfe581317c208103892bb84ca816d8aadaab.1659958805.git.stefan@agner.ch>
+In-Reply-To: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+References: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Fri, 5 Aug 2022 12:59:15 +0200
+Subject: [PATCH 05/11] Don't store is_default in json
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ libcontainer/devices/device.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libcontainer/devices/device.go b/libcontainer/devices/device.go
+index 9540a89c..ae59c6c5 100644
+--- a/libcontainer/devices/device.go
++++ b/libcontainer/devices/device.go
+@@ -26,7 +26,7 @@ type Device struct {
+ 	Gid uint32 `json:"gid"`
+ 
+ 	// Is Default Device
+-	IsDefault bool `json:"is_default"`
++	IsDefault bool `json:"-"`
+ }
+ 
+ // Permissions is a cgroupv1-style string to represent device access. It
+-- 
+2.37.1
+

--- a/package/runc/0006-Add-integration-tests-for-device-updates.patch
+++ b/package/runc/0006-Add-integration-tests-for-device-updates.patch
@@ -1,0 +1,83 @@
+From 9fb0e3c66d89da615f4c60a79328f405d98bc53e Mon Sep 17 00:00:00 2001
+Message-Id: <9fb0e3c66d89da615f4c60a79328f405d98bc53e.1659958805.git.stefan@agner.ch>
+In-Reply-To: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+References: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Fri, 5 Aug 2022 13:03:21 +0200
+Subject: [PATCH 06/11] Add integration tests for device updates
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ tests/integration/update.bats | 56 +++++++++++++++++++++++++++++++++++
+ 1 file changed, 56 insertions(+)
+
+diff --git a/tests/integration/update.bats b/tests/integration/update.bats
+index 01c69152..9e94837c 100644
+--- a/tests/integration/update.bats
++++ b/tests/integration/update.bats
+@@ -681,6 +681,62 @@ EOF
+ 	[ -z "$(<"$CONTAINER_OUTPUT")" ]
+ }
+ 
++
++@test "update devices" {
++	requires root
++
++	# Create a container without access to /dev/kmsg. Verify that accessing fails
++	# and update the container to add access from it.
++	#
++	# Finally, remove access again by passing an empty array of devices.
++	update_config ' .linux.resources.devices = [{"allow": false, "access": "rwm"}]
++			| .linux.devices = [{"path": "/dev/kmsg", "type": "c", "major": 1, "minor": 11}]
++			| .process.capabilities.bounding += ["CAP_SYSLOG"]
++			| .process.capabilities.effective += ["CAP_SYSLOG"]
++			| .process.capabilities.inheritable += ["CAP_SYSLOG"]
++			| .process.capabilities.permitted += ["CAP_SYSLOG"]'
++
++	# Run the container in the background.
++	runc run -d --console-socket "$CONSOLE_SOCKET" test_update_devices
++	[ "$status" -eq 0 ]
++
++	runc exec test_update_devices head -c 100 /dev/kmsg
++	[ "$status" -eq 1 ]
++
++	runc update --resources - test_update_devices <<EOF
++	{
++		"devices": [
++			{"allow": true, "type": "c", "major": 1, "minor": 11, "access": "rwa"}
++		]
++	}
++EOF
++
++	runc exec test_update_devices head -c 100 /dev/kmsg
++	[ "$status" -eq 0 ]
++
++
++	# Not updating devices should keep device access
++	# For backwards compatibility
++	runc update --resources - test_update_devices <<EOF
++	{ }
++EOF
++
++	runc exec test_update_devices head -c 100 /dev/kmsg
++	[ "$status" -eq 0 ]
++
++	# Explicitly removing access should remove access
++	runc update --resources - test_update_devices <<EOF
++	{
++		"devices": [
++			{"allow": false, "type": "c", "major": 1, "minor": 11, "access": "rwa"}
++		]
++	}
++EOF
++
++	runc exec test_update_devices head -c 100 /dev/kmsg
++	[ "$status" -eq 1 ]
++}
++
+ @test "update paused container" {
+ 	[[ "$ROOTLESS" -ne 0 ]] && requires rootless_cgroup
+ 	requires cgroups_freezer
+-- 
+2.37.1
+

--- a/package/runc/0007-Remove-duplicated-code.patch
+++ b/package/runc/0007-Remove-duplicated-code.patch
@@ -1,0 +1,73 @@
+From de64230684e24deaaa33bc4b717aeccf1d76fa0b Mon Sep 17 00:00:00 2001
+Message-Id: <de64230684e24deaaa33bc4b717aeccf1d76fa0b.1659958805.git.stefan@agner.ch>
+In-Reply-To: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+References: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Fri, 5 Aug 2022 17:52:26 +0200
+Subject: [PATCH 07/11] Remove duplicated code
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ libcontainer/specconv/spec_linux.go | 38 +++--------------------------
+ 1 file changed, 4 insertions(+), 34 deletions(-)
+
+diff --git a/libcontainer/specconv/spec_linux.go b/libcontainer/specconv/spec_linux.go
+index d51ac5c5..456eafde 100644
+--- a/libcontainer/specconv/spec_linux.go
++++ b/libcontainer/specconv/spec_linux.go
+@@ -727,36 +727,6 @@ func CreateCgroupConfig(opts *CreateOpts, defaultDevs []*devices.Device) (*confi
+ 	if spec.Linux != nil {
+ 		r = spec.Linux.Resources
+ 		if r != nil {
+-			for i, d := range spec.Linux.Resources.Devices {
+-				var (
+-					t     = "a"
+-					major = int64(-1)
+-					minor = int64(-1)
+-				)
+-				if d.Type != "" {
+-					t = d.Type
+-				}
+-				if d.Major != nil {
+-					major = *d.Major
+-				}
+-				if d.Minor != nil {
+-					minor = *d.Minor
+-				}
+-				if d.Access == "" {
+-					return nil, fmt.Errorf("device access at %d field cannot be empty", i)
+-				}
+-				dt, err := stringToCgroupDeviceRune(t)
+-				if err != nil {
+-					return nil, err
+-				}
+-				c.Resources.Devices = append(c.Resources.Devices, &devices.Rule{
+-					Type:        dt,
+-					Major:       major,
+-					Minor:       minor,
+-					Permissions: devices.Permissions(d.Access),
+-					Allow:       d.Allow,
+-				})
+-			}
+ 			if r.Memory != nil {
+ 				if r.Memory.Limit != nil {
+ 					c.Resources.Memory = *r.Memory.Limit
+@@ -885,11 +855,11 @@ func CreateCgroupConfig(opts *CreateOpts, defaultDevs []*devices.Device) (*confi
+ 				}
+ 			}
+ 		}
+-	}
+ 
+-	err := CreateCgroupDeviceConfig(c.Resources, r, defaultDevs)
+-	if err != nil {
+-		return nil, err
++		err := CreateCgroupDeviceConfig(c.Resources, r, defaultDevs)
++		if err != nil {
++			return nil, err
++		}
+ 	}
+ 
+ 	return c, nil
+-- 
+2.37.1
+

--- a/package/runc/0008-Revert-Don-t-store-is_default-in-json.patch
+++ b/package/runc/0008-Revert-Don-t-store-is_default-in-json.patch
@@ -1,0 +1,31 @@
+From 4733a41aed3326d514f3fd6d5b098d2a51f5193f Mon Sep 17 00:00:00 2001
+Message-Id: <4733a41aed3326d514f3fd6d5b098d2a51f5193f.1659958805.git.stefan@agner.ch>
+In-Reply-To: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+References: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Fri, 5 Aug 2022 17:53:34 +0200
+Subject: [PATCH 08/11] Revert "Don't store is_default in json"
+
+This reverts commit 2daa2e32e01dc198df877dc96c2d96faae4e04a0.
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ libcontainer/devices/device.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libcontainer/devices/device.go b/libcontainer/devices/device.go
+index ae59c6c5..9540a89c 100644
+--- a/libcontainer/devices/device.go
++++ b/libcontainer/devices/device.go
+@@ -26,7 +26,7 @@ type Device struct {
+ 	Gid uint32 `json:"gid"`
+ 
+ 	// Is Default Device
+-	IsDefault bool `json:"-"`
++	IsDefault bool `json:"is_default"`
+ }
+ 
+ // Permissions is a cgroupv1-style string to represent device access. It
+-- 
+2.37.1
+

--- a/package/runc/0009-Check-if-dev-null-is-accessible.patch
+++ b/package/runc/0009-Check-if-dev-null-is-accessible.patch
@@ -1,0 +1,41 @@
+From b8a173423463e54e9e36b2b98be1586114ce897a Mon Sep 17 00:00:00 2001
+Message-Id: <b8a173423463e54e9e36b2b98be1586114ce897a.1659958805.git.stefan@agner.ch>
+In-Reply-To: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+References: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Fri, 5 Aug 2022 17:58:12 +0200
+Subject: [PATCH 09/11] Check if /dev/null is accessible
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ tests/integration/update.bats | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/tests/integration/update.bats b/tests/integration/update.bats
+index 9e94837c..5f643da1 100644
+--- a/tests/integration/update.bats
++++ b/tests/integration/update.bats
+@@ -703,6 +703,10 @@ EOF
+ 	runc exec test_update_devices head -c 100 /dev/kmsg
+ 	[ "$status" -eq 1 ]
+ 
++	# Make sure default devices still work
++	runc exec test_update_devices cat /dev/null
++	[ "$status" -eq 0 ]
++
+ 	runc update --resources - test_update_devices <<EOF
+ 	{
+ 		"devices": [
+@@ -714,6 +718,9 @@ EOF
+ 	runc exec test_update_devices head -c 100 /dev/kmsg
+ 	[ "$status" -eq 0 ]
+ 
++	# Make sure default devices still work
++	runc exec test_update_devices cat /dev/null
++	[ "$status" -eq 0 ]
+ 
+ 	# Not updating devices should keep device access
+ 	# For backwards compatibility
+-- 
+2.37.1
+

--- a/package/runc/0010-Address-shfmt.patch
+++ b/package/runc/0010-Address-shfmt.patch
@@ -1,0 +1,28 @@
+From 0549cd8a4d39469e79735ee84beb2a77ec43549d Mon Sep 17 00:00:00 2001
+Message-Id: <0549cd8a4d39469e79735ee84beb2a77ec43549d.1659958805.git.stefan@agner.ch>
+In-Reply-To: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+References: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Fri, 5 Aug 2022 18:03:37 +0200
+Subject: [PATCH 10/11] Address shfmt
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ tests/integration/update.bats | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/tests/integration/update.bats b/tests/integration/update.bats
+index 5f643da1..f6dc30a9 100644
+--- a/tests/integration/update.bats
++++ b/tests/integration/update.bats
+@@ -681,7 +681,6 @@ EOF
+ 	[ -z "$(<"$CONTAINER_OUTPUT")" ]
+ }
+ 
+-
+ @test "update devices" {
+ 	requires root
+ 
+-- 
+2.37.1
+

--- a/package/runc/0011-Incremental-update-device-permission.patch
+++ b/package/runc/0011-Incremental-update-device-permission.patch
@@ -1,0 +1,31 @@
+From 455ee2c389ae43db2219949178f912bc19d962eb Mon Sep 17 00:00:00 2001
+Message-Id: <455ee2c389ae43db2219949178f912bc19d962eb.1659958805.git.stefan@agner.ch>
+In-Reply-To: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+References: <410089ea4bb8bf051a941febd087b0346b967a10.1659958805.git.stefan@agner.ch>
+From: Stefan Agner <stefan@agner.ch>
+Date: Mon, 8 Aug 2022 13:39:26 +0200
+Subject: [PATCH 11/11] Incremental update device permission
+
+---
+ update.go | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/update.go b/update.go
+index 9332515c..82ba0c8d 100644
+--- a/update.go
++++ b/update.go
+@@ -300,10 +300,7 @@ other options are ignored.
+ 		config.Cgroups.Resources.Unified = r.Unified
+ 
+ 		if len(r.Devices) > 0 {
+-			config.Cgroups.Resources.Devices = nil
+-			defaultAllowedDevices := specconv.CreateDefaultDevicesCgroups(&config)
+-
+-			err = specconv.CreateCgroupDeviceConfig(config.Cgroups.Resources, &r, defaultAllowedDevices)
++			err = specconv.CreateCgroupDeviceConfig(config.Cgroups.Resources, &r, nil)
+ 			if err != nil {
+ 				return err
+ 			}
+-- 
+2.37.1
+

--- a/package/runc/runc.mk
+++ b/package/runc/runc.mk
@@ -10,7 +10,7 @@ RUNC_LICENSE = Apache-2.0, LGPL-2.1 (libseccomp)
 RUNC_LICENSE_FILES = LICENSE
 RUNC_CPE_ID_VENDOR = linuxfoundation
 
-RUNC_LDFLAGS = -X main.version=$(RUNC_VERSION)
+RUNC_LDFLAGS = -X main.version=$(RUNC_VERSION)-haos
 RUNC_TAGS = cgo static_build
 
 ifeq ($(BR2_PACKAGE_LIBAPPARMOR),y)

--- a/package/systemd/systemd.mk
+++ b/package/systemd/systemd.mk
@@ -61,7 +61,7 @@ SYSTEMD_SELINUX_MODULES = systemd udev xdg
 SYSTEMD_PROVIDES = udev
 
 SYSTEMD_CONF_OPTS += \
-	-Ddefault-hierarchy=hybrid \
+	-Ddefault-hierarchy=unified \
 	-Didn=true \
 	-Dima=false \
 	-Dkexec-path=/usr/sbin/kexec \


### PR DESCRIPTION
This patchset (re-)enables Control Group v2. It also adds support for device permission updates to runc which is required by OS-Agent to provide a working `AddDevicesAllowed` API for Control Group v2.

This requires https://github.com/home-assistant/os-agent/pull/92 to be useful.