### PR TITLE
Update dropbear to 2022.83

### DIFF
--- a/package/dropbear/dropbear.mk
+++ b/package/dropbear/dropbear.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-DROPBEAR_VERSION = 2020.81
+DROPBEAR_VERSION = 2022.83
 DROPBEAR_SITE = https://matt.ucc.asn.au/dropbear/releases
 DROPBEAR_SOURCE = dropbear-$(DROPBEAR_VERSION).tar.bz2
 DROPBEAR_LICENSE = MIT, BSD-2-Clause, Public domain


### PR DESCRIPTION
The dropbear version is quite old.
The old version for example does not yet support security key protected ssh keys.
Release notes: https://github.com/mkj/dropbear/releases/tag/DROPBEAR_2022.83

Side note: This is just a guess how to update this component. I also have no idea about potential side effects and how to test the new version properly.