### PR TITLE
Bump docker from v20.10.22 to v23.0.0

### DIFF
--- a/package/docker-cli/docker-cli.mk
+++ b/package/docker-cli/docker-cli.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-DOCKER_CLI_VERSION = 20.10.22
+DOCKER_CLI_VERSION = 23.0.0
 DOCKER_CLI_SITE = $(call github,docker,cli,v$(DOCKER_CLI_VERSION))
 
 DOCKER_CLI_LICENSE = Apache-2.0

--- a/package/docker-engine/docker-engine.mk
+++ b/package/docker-engine/docker-engine.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-DOCKER_ENGINE_VERSION = 20.10.22
+DOCKER_ENGINE_VERSION = 23.0.0
 DOCKER_ENGINE_SITE = $(call github,moby,moby,v$(DOCKER_ENGINE_VERSION))
 
 DOCKER_ENGINE_LICENSE = Apache-2.0


### PR DESCRIPTION
https://github.com/moby/moby/releases/tag/v23.0.0

Going forward it will be easier to keep up with new updates to docker, since they are switching to SemVer.

This updates adds CAP_PERFMON and CAP_BPF as new privileged capabilities, which in turn is necessary on https://github.com/home-assistant/operating-system/discussions/2319.