### PR TITLE
package/linux-firmware: add RTL8851/RTL8852 firmware

### DIFF
--- a/package/linux-firmware/linux-firmware.mk
+++ b/package/linux-firmware/linux-firmware.mk
@@ -84,7 +84,11 @@ LINUX_FIRMWARE_FILES += \
 	rtl_bt/rtl8821c_config.bin rtl_bt/rtl8821c_fw.bin \
 	rtl_bt/rtl8822b_config.bin rtl_bt/rtl8822b_fw.bin \
 	rtl_bt/rtl8822cs_config.bin rtl_bt/rtl8822cs_fw.bin \
-	rtl_bt/rtl8822cu_config.bin rtl_bt/rtl8822cu_fw.bin
+	rtl_bt/rtl8822cu_config.bin rtl_bt/rtl8822cu_fw.bin \
+	rtl_bt/rtl8851bu_fw.bin rtl_bt/rtl8851bu_config.bin \
+	rtl_bt/rtl8852au_fw.bin rtl_bt/rtl8852au_config.bin \
+	rtl_bt/rtl8852bu_fw.bin rtl_bt/rtl8852bu_config.bin \
+	rtl_bt/rtl8852cu_fw.bin rtl_bt/rtl8852cu_config.bin
 LINUX_FIRMWARE_ALL_LICENSE_FILES += LICENCE.rtlwifi_firmware.txt
 endif
 


### PR DESCRIPTION
Add firmware files for RTL8851 and RTL8852 cards used by the rtlbt driver.