### PR TITLE
package/rpi-firmware: bump to version for stable_20231030 kernel

### DIFF
--- a/package/rpi-firmware/rpi-firmware.mk
+++ b/package/rpi-firmware/rpi-firmware.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_FIRMWARE_VERSION = 055e044d5359ded1aacc5a17a8e35365373d0b8b
+RPI_FIRMWARE_VERSION = bb23149e1d02aee987248e978ea70b1b7f0022e9
 RPI_FIRMWARE_SITE = $(call github,raspberrypi,firmware,$(RPI_FIRMWARE_VERSION))
 RPI_FIRMWARE_LICENSE = BSD-3-Clause
 RPI_FIRMWARE_LICENSE_FILES = boot/LICENCE.broadcom


### PR DESCRIPTION
Since overlays are used from the rpi-firmware package, we must keep it in sync with the kernel used.