### PR TITLE
package/rpi-firmware: update package tarball hash

### DIFF
--- a/package/rpi-firmware/rpi-firmware.hash
+++ b/package/rpi-firmware/rpi-firmware.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256  a13bdcc5bf19f7c9350c9a8d5f5eb3622eb69a8095548e0d6e7944072dbd56b4  rpi-firmware-055e044d5359ded1aacc5a17a8e35365373d0b8b.tar.gz
+sha256  0d6a2ca0e388a9174b16111ba1c5f82c4fe9f71160d8478f4cb55625014d5fcc  rpi-firmware-bb23149e1d02aee987248e978ea70b1b7f0022e9.tar.gz
 sha256  c7283ff51f863d93a275c66e3b4cb08021a5dd4d8c1e7acc47d872fbe52d3d6b  boot/LICENCE.broadcom


### PR DESCRIPTION
Update package hash that was missing in a48cc458e721571da04696ee9f1341e3f9e86702