### PR TITLE
linux-firmware: add option for firmware files compression

### DIFF
--- a/package/linux-firmware/Config.in
+++ b/package/linux-firmware/Config.in
@@ -8,6 +8,32 @@ config BR2_PACKAGE_LINUX_FIRMWARE
 
 if BR2_PACKAGE_LINUX_FIRMWARE
 
+config BR2_PACKAGE_LINUX_FIRMWARE_COMPRESS
+    bool "Compress firmware files"
+    help
+      Compress firmware files to save space in the root filesystem. This
+      is not as efficient as whole root filesystem compression, but it
+      is better performance-wise, because the firmwares are usually
+      accessed only when the driver is loaded.
+
+if BR2_PACKAGE_LINUX_FIRMWARE_COMPRESS
+
+choice
+	prompt "Compression algorithm"
+	default BR2_PACKAGE_LINUX_FIRMWARE_COMPRESS_XZ
+	help
+	  Select the compression algorithm to use for the firmware files.
+
+config BR2_PACKAGE_LINUX_FIRMWARE_COMPRESS_XZ
+	bool "xz"
+
+config BR2_PACKAGE_LINUX_FIRMWARE_COMPRESS_ZSTD
+	bool "zstd"
+
+endchoice
+
+endif
+
 menu "Audio firmware"
 
 config BR2_PACKAGE_LINUX_FIRMWARE_INTEL_SST_DSP

--- a/package/linux-firmware/linux-firmware.mk
+++ b/package/linux-firmware/linux-firmware.mk
@@ -11,6 +11,19 @@ LINUX_FIRMWARE_INSTALL_IMAGES = YES
 
 LINUX_FIRMWARE_CPE_ID_VENDOR = kernel
 
+LINUX_FIRMWARE_COMPRESSED_FILE_SUFFIX=
+ifeq ($(BR2_PACKAGE_LINUX_FIRMWARE_COMPRESS_XZ),y)
+LINUX_FIRMWARE_DEPENDENCIES += host-xz
+LINUX_FIRMWARE_COMPRESS_CMD=$(HOST_DIR)/bin/xz -fv -C crc32 --lzma2=dict=2MiB
+LINUX_FIRMWARE_COMPRESSED_FILE_SUFFIX=.xz
+else
+ifeq ($(BR2_PACKAGE_LINUX_FIRMWARE_COMPRESS_ZSTD),y)
+LINUX_FIRMWARE_DEPENDENCIES += host-zstd
+LINUX_FIRMWARE_COMPRESS_CMD=$(HOST_DIR)/bin/zstd -f -19 --rm
+LINUX_FIRMWARE_COMPRESSED_FILE_SUFFIX=.zst
+endif
+endif
+
 # Intel SST DSP
 ifeq ($(BR2_PACKAGE_LINUX_FIRMWARE_INTEL_SST_DSP),y)
 LINUX_FIRMWARE_FILES += intel/fw_sst_0f28.bin-48kHz_i2s_master
@@ -835,15 +848,34 @@ LINUX_FIRMWARE_LICENSE_FILES = $(sort $(LINUX_FIRMWARE_ALL_LICENSE_FILES))
 # sure we canonicalize the pointed-to file, to cover the symlinks of the form
 # a/foo -> ../b/foo  where a/ (the directory where to put the symlink) does
 # not yet exist.
+#
+# If BR2_PACKAGE_LINUX_FIRMWARE_COMPRESS is enabled, modules are compressed
+# in this stage after being copied to the target directory. The compression
+# is not done on modules in the images directory, because they must not be
+# compressed when bundled via the EXTRA_FIRMWARE option.
+#
+# $1: target directory
+# $2: 'images' (uncompressed) or 'target' (compressed if enabled)
 define LINUX_FIRMWARE_INSTALL_FW
 	mkdir -p $(1)
 	$(TAR) xf $(@D)/br-firmware.tar -C $(1)
+	if [ "$(BR2_PACKAGE_LINUX_FIRMWARE_COMPRESS)" = "y" ] && [ "$(2)" = "target" ]; then \
+		$(TAR) tf $(@D)/br-firmware.tar | while read f; do \
+			if [ -f $(1)/$$f ]; then \
+				$(LINUX_FIRMWARE_COMPRESS_CMD) $(1)/$$f; \
+			fi ; \
+		done ; \
+	fi
 	cd $(1) ; \
+	file_suffix="" ; \
+	if [ "$(BR2_PACKAGE_LINUX_FIRMWARE_COMPRESS)" = "y" ] && [ "$(2)" = "target" ]; then \
+		file_suffix="$(LINUX_FIRMWARE_COMPRESSED_FILE_SUFFIX)" ; \
+	fi ; \
 	sed -r -e '/^Link: (.+) -> (.+)$$/!d; s//\1 \2/' $(@D)/WHENCE | \
 	while read f d; do \
-		if test -f $$(readlink -m $$(dirname "$$f")/$$d); then \
+		if test -f $$(readlink -m $$(dirname "$$f")/$${d}$${file_suffix}); then \
 			mkdir -p $$(dirname "$$f") || exit 1; \
-			ln -sf $$d "$$f" || exit 1; \
+			ln -sf $${d}$${file_suffix} "$${f}$${file_suffix}" || exit 1; \
 		fi ; \
 	done
 endef
@@ -851,11 +883,22 @@ endef
 endif  # LINUX_FIRMWARE_FILES || LINUX_FIRMWARE_DIRS
 
 define LINUX_FIRMWARE_INSTALL_TARGET_CMDS
-	$(call LINUX_FIRMWARE_INSTALL_FW, $(TARGET_DIR)/lib/firmware)
+	$(call LINUX_FIRMWARE_INSTALL_FW,$(TARGET_DIR)/lib/firmware,target)
 endef
 
 define LINUX_FIRMWARE_INSTALL_IMAGES_CMDS
-	$(call LINUX_FIRMWARE_INSTALL_FW, $(BINARIES_DIR))
+	$(call LINUX_FIRMWARE_INSTALL_FW,$(BINARIES_DIR),images)
+endef
+
+define LINUX_FIRMWARE_LINUX_CONFIG_FIXUPS
+	$(if $(BR2_PACKAGE_LINUX_FIRMWARE_COMPRESS_XZ),
+		$(call KCONFIG_ENABLE_OPT,CONFIG_FW_LOADER_COMPRESS)
+		$(call KCONFIG_ENABLE_OPT,CONFIG_FW_LOADER_COMPRESS_XZ)
+		$(call KCONFIG_DISABLE_OPT,CONFIG_FW_LOADER_COMPRESS_ZSTD))
+	$(if $(BR2_PACKAGE_LINUX_FIRMWARE_COMPRESS_ZSTD),
+		$(call KCONFIG_ENABLE_OPT,CONFIG_FW_LOADER_COMPRESS)
+		$(call KCONFIG_DISABLE_OPT,CONFIG_FW_LOADER_COMPRESS_XZ)
+		$(call KCONFIG_ENABLE_OPT,CONFIG_FW_LOADER_COMPRESS_ZSTD))
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
Add option for compression of the firmware files. This can save some space in the rootfs if less efficient (or none) compression is used for the whole FS. The files are compressed in the install stage, because different behavior is needed when being installed to the target or to the images directory (where there are later picked up by the kernel build). This means that the target directory may contain both compressed and uncompressed images if the option is changed between builds without cleaning in between, but similar inconsistencies may be encountered when selecting individual firmwares to deploy.