### PR TITLE
package/{bluez5_utils, bluez5_utils-headers}: bump to version 5.72

### DIFF
--- a/package/bluez5_utils-headers/bluez5_utils-headers.mk
+++ b/package/bluez5_utils-headers/bluez5_utils-headers.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 # Keep the version and patches in sync with bluez5_utils
-BLUEZ5_UTILS_HEADERS_VERSION = 5.70
+BLUEZ5_UTILS_HEADERS_VERSION = 5.72
 BLUEZ5_UTILS_HEADERS_SOURCE = bluez-$(BLUEZ5_UTILS_VERSION).tar.xz
 BLUEZ5_UTILS_HEADERS_SITE = $(BR2_KERNEL_MIRROR)/linux/bluetooth
 BLUEZ5_UTILS_HEADERS_DL_SUBDIR = bluez5_utils

--- a/package/bluez5_utils/bluez5_utils.hash
+++ b/package/bluez5_utils/bluez5_utils.hash
@@ -1,5 +1,5 @@
 # From https://www.kernel.org/pub/linux/bluetooth/sha256sums.asc:
-sha256  37e372e916955e144cb882f888e4be40898f10ae3b7c213ddcdd55ee9c009278  bluez-5.70.tar.xz
+sha256  499d7fa345a996c1bb650f5c6749e1d929111fa6ece0be0e98687fee6124536e  bluez-5.72.tar.xz
 # Locally computed
 sha256  b499eddebda05a8859e32b820a64577d91f1de2b52efa2a1575a2cb4000bc259  COPYING
 sha256  ec60b993835e2c6b79e6d9226345f4e614e686eb57dc13b6420c15a33a8996e5  COPYING.LIB

--- a/package/bluez5_utils/bluez5_utils.mk
+++ b/package/bluez5_utils/bluez5_utils.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 # Keep the version and patches in sync with bluez5_utils-headers
-BLUEZ5_UTILS_VERSION = 5.70
+BLUEZ5_UTILS_VERSION = 5.72
 BLUEZ5_UTILS_SOURCE = bluez-$(BLUEZ5_UTILS_VERSION).tar.xz
 BLUEZ5_UTILS_SITE = $(BR2_KERNEL_MIRROR)/linux/bluetooth
 BLUEZ5_UTILS_INSTALL_STAGING = YES


### PR DESCRIPTION
ver 5.72:
	Fix issue with BAP and handling stream IO linking.
	Fix issue with BAP and setup of multiple streams per endpoint.
	Fix issue with AVDTP and potential incorrect transaction label.
	Fix issue with A2DP and handling crash on suspend.
	Fix issue with GATT database and an invalid pointer.
	Add support for AICS service.

ver 5.71:
	Fix issue with not registering CSIS service.
	Fix issue with registering pairing callbacks.
	Fix issue with corruption during discovery filter parsing.