### PR TITLE
package/dbus: set runstatedir to /run

### DIFF
--- a/package/dbus/dbus.mk
+++ b/package/dbus/dbus.mk
@@ -33,7 +33,8 @@ DBUS_CONF_OPTS = \
 	--disable-xml-docs \
 	--disable-doxygen-docs \
 	--with-system-socket=/run/dbus/system_bus_socket \
-	--with-system-pid-file=/run/messagebus.pid
+	--with-system-pid-file=/run/messagebus.pid \
+	--runstatedir=/run
 
 ifeq ($(BR2_STATIC_LIBS),y)
 DBUS_CONF_OPTS += LIBS='-pthread'


### PR DESCRIPTION
DBus 1.14.x now has the Containers1 interface which uses path in runstatedir (by default set to /var/run) for creating sockets. With the default, Systemd complains about it being a legacy directory:

systemd-tmpfiles[102]: /usr/lib/tmpfiles.d/dbus.conf:13: Line references path below legacy directory /var/run/, updating /var/run/dbus/containers → /run/dbus/containers; please update the tmpfiles.d/ drop-in file accordingly.

Set the configure option runstatedir to /run to use the preferred path to avoid the warning and use the /run directory consistently. Setting the value only affects the path of these sockets and to the PID file, which is already explicitly set by another option.