### PR TITLE
package/{bluez5_utils, bluez5_utils-headers}: bump to version 5.75

### DIFF
--- a/package/bluez5_utils-headers/bluez5_utils-headers.mk
+++ b/package/bluez5_utils-headers/bluez5_utils-headers.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 # Keep the version and patches in sync with bluez5_utils
-BLUEZ5_UTILS_HEADERS_VERSION = 5.72
+BLUEZ5_UTILS_HEADERS_VERSION = 5.75
 BLUEZ5_UTILS_HEADERS_SOURCE = bluez-$(BLUEZ5_UTILS_VERSION).tar.xz
 BLUEZ5_UTILS_HEADERS_SITE = $(BR2_KERNEL_MIRROR)/linux/bluetooth
 BLUEZ5_UTILS_HEADERS_DL_SUBDIR = bluez5_utils

--- a/package/bluez5_utils/0001-configure.ac-Fix-disable-cups.patch
+++ b/package/bluez5_utils/0001-configure.ac-Fix-disable-cups.patch
@@ -1,0 +1,41 @@
+From cb0de49bc6f8a6bf8f01a24599b499aa4bf18032 Mon Sep 17 00:00:00 2001
+From: Lars Wendler <polynomial-c@gmx.de>
+Date: Tue, 16 Apr 2024 07:26:04 +0200
+Subject: [PATCH] configure.ac: Fix --disable-cups
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+or else we get:
+  configure: error: conditional "CUPS_SERVERBIN" was never defined.
+  Usually this means the macro was only invoked conditionally.
+
+Fixes: https://github.com/bluez/bluez/issues/773
+
+Upstream: https://patchwork.kernel.org/project/bluetooth/list/?series=844910
+Signed-off-by: Jan Čermák <sairon@sairon.cz>
+---
+ configure.ac | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 9dea70d..dbba759 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -249,12 +249,12 @@ AM_CONDITIONAL(CUPS, test "${enable_cups}" != "no")
+ if (test "${enable_cups}" != "no"); then
+ 	AC_MSG_CHECKING([cups directory])
+ 	cups_serverbin=`$PKG_CONFIG cups --variable=cups_serverbin`
+-	AM_CONDITIONAL(CUPS_SERVERBIN, test "${cups_serverbin}" != "")
+-	if (test "${cups_serverbin}" != ""); then
+-		AC_SUBST(CUPS_SERVERBIN, ${cups_serverbin})
+-	fi
+ 	AC_MSG_RESULT([${cups_serverbin}])
+ fi
++AM_CONDITIONAL(CUPS_SERVERBIN, test "${cups_serverbin}" != "")
++AS_IF([test "${cups_serverbin}" != ""],[
++	AC_SUBST(CUPS_SERVERBIN, ${cups_serverbin})
++])
+ 
+ AC_ARG_ENABLE(mesh, AS_HELP_STRING([--enable-mesh],
+ 		[enable Mesh profile support]), [enable_mesh=${enableval}])

--- a/package/bluez5_utils/bluez5_utils.hash
+++ b/package/bluez5_utils/bluez5_utils.hash
@@ -1,5 +1,5 @@
 # From https://www.kernel.org/pub/linux/bluetooth/sha256sums.asc:
-sha256  499d7fa345a996c1bb650f5c6749e1d929111fa6ece0be0e98687fee6124536e  bluez-5.72.tar.xz
+sha256  988cb3c4551f6e3a667708a578f5ca9f93fc896508f98f08709be4f8ab033c2f  bluez-5.75.tar.xz
 # Locally computed
 sha256  b499eddebda05a8859e32b820a64577d91f1de2b52efa2a1575a2cb4000bc259  COPYING
 sha256  ec60b993835e2c6b79e6d9226345f4e614e686eb57dc13b6420c15a33a8996e5  COPYING.LIB

--- a/package/bluez5_utils/bluez5_utils.mk
+++ b/package/bluez5_utils/bluez5_utils.mk
@@ -5,9 +5,11 @@
 ################################################################################
 
 # Keep the version and patches in sync with bluez5_utils-headers
-BLUEZ5_UTILS_VERSION = 5.72
+BLUEZ5_UTILS_VERSION = 5.75
 BLUEZ5_UTILS_SOURCE = bluez-$(BLUEZ5_UTILS_VERSION).tar.xz
 BLUEZ5_UTILS_SITE = $(BR2_KERNEL_MIRROR)/linux/bluetooth
+# 0001-configure.ac-Fix-disable-cups.patch
+BLUEZ5_UTILS_AUTORECONF = YES
 BLUEZ5_UTILS_INSTALL_STAGING = YES
 BLUEZ5_UTILS_LICENSE = GPL-2.0+, LGPL-2.1+
 BLUEZ5_UTILS_LICENSE_FILES = COPYING COPYING.LIB


### PR DESCRIPTION
Bump to version 5.75 containing various fixes. Added a patch to fix build with disabled CUPS (failing since 5.73, waiting to be reviewed and merged) and enabled autoreconf which is needed for that patch.

Changelog:
https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/ChangeLog