### PR TITLE
Install overlay_map.dtb when using in-tree DT overlays

### DIFF
--- a/linux/linux.mk
+++ b/linux/linux.mk
@@ -462,8 +462,10 @@ endef
 endif # BR2_LINUX_KERNEL_APPENDED_DTB
 ifeq ($(BR2_LINUX_KERNEL_INSTALL_INTREE_OVERLAYS),y)
 define LINUX_INSTALL_OVERLAYS
-	install -D -t $(1)/overlays/ \
-			$(wildcard $(LINUX_ARCH_PATH)/boot/dts/overlays/*.dtbo)
+	$(foreach ovldtb,$(wildcard $(LINUX_ARCH_PATH)/boot/dts/overlays/*.dtbo), \
+		$(INSTALL) -D -m 0644 $(ovldtb) $(1)/overlays/$(notdir $(ovldtb))
+	)
+	$(INSTALL) -D -m 0644 $(LINUX_ARCH_PATH)/boot/dts/overlays/overlay_map.dtb $(1)/overlays/
 endef
 endif # BR2_LINUX_KERNEL_INSTALL_INTREE_OVERLAYS
 endif # BR2_LINUX_KERNEL_DTB_IS_SELF_BUILT


### PR DESCRIPTION
Unlike the rest of the overlays directory, this file has .dtb suffix, which results for it not being installed when copying *.dtbo wildcard. It is necessary for correct mapping of overlays without RPi version suffix to the platform-specific ones.

Also use a foreach loop for installing the overlays to set the mode to 0644, just like when rpi-firmware package installs them.