### PR TITLE
.github: remove upstream's PR template discouraging GH usage

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,0 @@
-Please do not submit a Pull Request via GitHub. Buildroot makes use of a
-[mailing list](http://lists.buildroot.org/mailman/listinfo/buildroot) for patch submission and review.
-See [submitting your own patches](http://buildroot.org/manual.html#submitting-patches) for more info.
-
-Thanks for your help!
-


### PR DESCRIPTION
We actually use Github and the template text is not relevant to us.