### PR TITLE
package/linux-firmware: add iwlwifi gl firmware

### DIFF
--- a/package/linux-firmware/Config.in
+++ b/package/linux-firmware/Config.in
@@ -362,6 +362,12 @@ config BR2_PACKAGE_LINUX_FIRMWARE_IWLWIFI_QUZ
 	  Firmware files for the Intel Wifi QuZ devices (used in NUC10)
 	  supported by the iwlwifi kernel driver.
 
+config BR2_PACKAGE_LINUX_FIRMWARE_IWLWIFI_GL
+	bool "Intel iwlwifi GL"
+	help
+	  Firmware files for the Intel Wifi GL devices (used in BE200)
+	  supported by the iwlwifi kernel driver.
+
 config BR2_PACKAGE_LINUX_FIRMWARE_LIBERTAS_SD8686_V8
 	bool "Libertas SD 8686 v8"
 	help

--- a/package/linux-firmware/linux-firmware.mk
+++ b/package/linux-firmware/linux-firmware.mk
@@ -541,6 +541,7 @@ LINUX_FIRMWARE_AX210_UCODE_API_MAX = 83
 # The 9560 driver has maximum ucode API defined in ax210.c yet its versions
 # are seemingly tracking the 22000 series.
 LINUX_FIRMWARE_AX210_UCODE_API_MAX_9560 = 77
+LINUX_FIRMWARE_IWL_BZ_UCODE_API_MAX = 83
 
 ifeq ($(BR2_PACKAGE_LINUX_FIRMWARE_IWLWIFI_22000),y)
 LINUX_FIRMWARE_FILES += \
@@ -645,6 +646,13 @@ endif
 
 ifeq ($(BR2_PACKAGE_LINUX_FIRMWARE_IWLWIFI_QUZ),y)
 LINUX_FIRMWARE_FILES += iwlwifi-QuZ-*.ucode
+LINUX_FIRMWARE_ALL_LICENSE_FILES += LICENCE.iwlwifi_firmware
+endif
+
+ifeq ($(BR2_PACKAGE_LINUX_FIRMWARE_IWLWIFI_GL),y)
+LINUX_FIRMWARE_FILES += \
+	iwlwifi-gl-c0-fm-c0-$(LINUX_FIRMWARE_IWL_BZ_UCODE_API_MAX).ucode\
+	iwlwifi-gl-c0-fm-c0.pnvm
 LINUX_FIRMWARE_ALL_LICENSE_FILES += LICENCE.iwlwifi_firmware
 endif
 


### PR DESCRIPTION
This commit integrates support for the iwlwifi gl firmware files to support the wifi chipsets for the intel BE200 type of hardware. Thus, this change adds BR2_PACKAGE_LINUX_FIRMWARE_IWLWIFI_GL.

To be honest, personally, I'd add this to already existing umbrella for Intel 6/6E adapters, instead of adding yet another build switch. Because, either we enable all Intel 6/6E adapters, or we enable them one by one.

But, just in case,  made it with additional switch. 
Alternatively I can rework into other version.