### PR TITLE
package/busybox: patch to fix tc build on 6.8+ kernels

### DIFF
--- a/package/busybox/0010-Linux-v6.8-rc1-removed-the-definitions-related-to-CB.patch
+++ b/package/busybox/0010-Linux-v6.8-rc1-removed-the-definitions-related-to-CB.patch
@@ -1,0 +1,70 @@
+From c4f93565acf3718111cdbaea15e1a8aacf2f44cf Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Uwe=20Kleine-K=C3=B6nig?= <u.kleine-koenig@pengutronix.de>
+Date: Mon, 23 Sep 2024 18:56:00 +0200
+Subject: [PATCH] tc: Fix compilation with Linux v6.8-rc1
+
+Linux v6.8-rc1 removed the definitions related to CBQ:
+https://github.com/torvalds/linux/commit/33241dca486264193ed68167c8eeae1fb197f3df
+making tc fail to build.
+Add some #ifdefs to handle this missing support.
+
+Upstream: http://lists.busybox.net/pipermail/busybox/2024-March/090678.html
+Bug report: https://bugs.busybox.net/show_bug.cgi?id=15931
+
+Signed-off-by: Bernd Kuhls <bernd@kuhls.net>
+---
+ networking/tc.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/networking/tc.c b/networking/tc.c
+index 3a79fd2d9..d08fd1359 100644
+--- a/networking/tc.c
++++ b/networking/tc.c
+@@ -231,6 +231,13 @@ static int cbq_parse_opt(int argc, char **argv, struct nlmsghdr *n)
+ 	return 0;
+ }
+ #endif
++
++#ifndef TCA_CBQ_MAX
++/*
++ * Linux v6.8-rc1~131^2~60^2^2 removed the uapi definitions for CBQ.
++ * See https://git.kernel.org/linus/33241dca48626
++ */
++#else
+ static int cbq_print_opt(struct rtattr *opt)
+ {
+ 	struct rtattr *tb[TCA_CBQ_MAX+1];
+@@ -322,6 +329,7 @@ static int cbq_print_opt(struct rtattr *opt)
+  done:
+ 	return 0;
+ }
++#endif
+ 
+ static FAST_FUNC int print_qdisc(
+ 		const struct sockaddr_nl *who UNUSED_PARAM,
+@@ -372,8 +380,10 @@ static FAST_FUNC int print_qdisc(
+ 		int qqq = index_in_strings(_q_, name);
+ 		if (qqq == 0) { /* pfifo_fast aka prio */
+ 			prio_print_opt(tb[TCA_OPTIONS]);
++#ifdef TCA_CBQ_MAX
+ 		} else if (qqq == 1) { /* class based queuing */
+ 			cbq_print_opt(tb[TCA_OPTIONS]);
++#endif
+ 		} else {
+ 			/* don't know how to print options for this qdisc */
+ 			printf("(options for %s)", name);
+@@ -442,9 +452,11 @@ static FAST_FUNC int print_class(
+ 		int qqq = index_in_strings(_q_, name);
+ 		if (qqq == 0) { /* pfifo_fast aka prio */
+ 			/* nothing. */ /*prio_print_opt(tb[TCA_OPTIONS]);*/
++#ifdef TCA_CBQ_MAX
+ 		} else if (qqq == 1) { /* class based queuing */
+ 			/* cbq_print_copt() is identical to cbq_print_opt(). */
+ 			cbq_print_opt(tb[TCA_OPTIONS]);
++#endif
+ 		} else {
+ 			/* don't know how to print options for this class */
+ 			printf("(options for %s)", name);
+-- 
+2.39.5
+


### PR DESCRIPTION
Fixes a build error introduced by bumping the linux kernel headers to 6.8 with buildroot commit 807a44925697b9567d5bd9872a334a073b3dcf55.

No autobuilder failures were recorded with this problem.