### PR TITLE
Cherry-pick package/linux-pam changes for pam_lastlog.so

### DIFF
--- a/package/linux-pam/Config.in
+++ b/package/linux-pam/Config.in
@@ -11,6 +11,15 @@ config BR2_PACKAGE_LINUX_PAM
 
 	  http://linux-pam.org
 
+if BR2_PACKAGE_LINUX_PAM
+
+config BR2_PACKAGE_LINUX_PAM_LASTLOG
+	bool "pam_lastlog.so"
+	help
+	  Build pam_lastlog.so module.
+
+endif
+
 comment "linux-pam needs a toolchain w/ wchar, locale, dynamic library, gcc >= 4.9"
 	depends on BR2_USE_MMU
 	depends on !BR2_ENABLE_LOCALE || !BR2_USE_WCHAR \

--- a/package/linux-pam/linux-pam.mk
+++ b/package/linux-pam/linux-pam.mk
@@ -54,6 +54,12 @@ else
 LINUX_PAM_CONF_OPTS += --disable-openssl
 endif
 
+ifeq ($(BR2_PACKAGE_LINUX_PAM_LASTLOG),y)
+LINUX_PAM_CONF_OPTS += --enable-lastlog
+else
+LINUX_PAM_CONF_OPTS += --disable-lastlog
+endif
+
 # Install default pam config (deny everything except login)
 define LINUX_PAM_INSTALL_CONFIG
 	$(INSTALL) -m 0644 -D package/linux-pam/login.pam \

--- a/package/linux-pam/linux-pam.mk
+++ b/package/linux-pam/linux-pam.mk
@@ -56,6 +56,10 @@ endif
 
 ifeq ($(BR2_PACKAGE_LINUX_PAM_LASTLOG),y)
 LINUX_PAM_CONF_OPTS += --enable-lastlog
+define LINUX_PAM_LASTLOG_PAMFILE_TWEAK
+	$(SED) 's/^# \(.*pam_lastlog.so.*\)$$/\1/' \
+		$(TARGET_DIR)/etc/pam.d/login
+endef
 else
 LINUX_PAM_CONF_OPTS += --disable-lastlog
 endif
@@ -66,6 +70,7 @@ define LINUX_PAM_INSTALL_CONFIG
 		$(TARGET_DIR)/etc/pam.d/login
 	$(INSTALL) -m 0644 -D package/linux-pam/other.pam \
 		$(TARGET_DIR)/etc/pam.d/other
+	$(LINUX_PAM_LASTLOG_PAMFILE_TWEAK)
 	$(LINUX_PAM_SELINUX_PAMFILE_TWEAK)
 endef
 

--- a/package/linux-pam/login.pam
+++ b/package/linux-pam/login.pam
@@ -8,5 +8,5 @@ password	required	pam_unix.so nullok
 session		required	pam_limits.so
 session		required	pam_env.so
 session		required	pam_unix.so
-session		optional	pam_lastlog.so
+# session	optional	pam_lastlog.so
 # session	required	pam_selinux.so open


### PR DESCRIPTION
Cherry-pick changes that are needed to stop PAM including pam_lastlog.so which is not built since linux-pam 1.5.3. Instead of disabling the line in a downstream patch, cherry-pick changes that effectively do the same.