### PR TITLE
package/linux-firmware: update Intel iwlwifi firmware versions for Linux 6.12

### DIFF
--- a/package/linux-firmware/linux-firmware.mk
+++ b/package/linux-firmware/linux-firmware.mk
@@ -537,11 +537,13 @@ LINUX_FIRMWARE_IWL8000_UCODE_API_MAX = 36
 LINUX_FIRMWARE_IWL8265_UCODE_API_MAX = 36
 LINUX_FIRMWARE_IWL9000_UCODE_API_MAX = 46
 LINUX_FIRMWARE_IWL_22000_UCODE_API_MAX = 77
-LINUX_FIRMWARE_AX210_UCODE_API_MAX = 83
+# Capped by linux-firmware, Linux 6.12 has max 89
+LINUX_FIRMWARE_IWL_AX210_UCODE_API_MAX = 86
 # The 9560 driver has maximum ucode API defined in ax210.c yet its versions
 # are seemingly tracking the 22000 series.
-LINUX_FIRMWARE_AX210_UCODE_API_MAX_9560 = 77
-LINUX_FIRMWARE_IWL_BZ_UCODE_API_MAX = 83
+LINUX_FIRMWARE_IWL_AX210_UCODE_API_MAX_9560 = 77
+# Capped by linux-firmware, Linux 6.12 has max 93
+LINUX_FIRMWARE_IWL_BZ_UCODE_API_MAX = 86
 
 ifeq ($(BR2_PACKAGE_LINUX_FIRMWARE_IWLWIFI_22000),y)
 LINUX_FIRMWARE_FILES += \
@@ -635,11 +637,11 @@ endif
 # it only has firmware only up to version 77, like other in 22000.
 ifeq ($(BR2_PACKAGE_LINUX_FIRMWARE_IWLWIFI_6E),y)
 LINUX_FIRMWARE_FILES += \
-	iwlwifi-so-a0-jf-b0-$(LINUX_FIRMWARE_AX210_UCODE_API_MAX_9560).ucode \
-	iwlwifi-so-a0-hr-b0-$(LINUX_FIRMWARE_AX210_UCODE_API_MAX).ucode \
-	iwlwifi-so-a0-gf-a0-$(LINUX_FIRMWARE_AX210_UCODE_API_MAX).ucode \
+	iwlwifi-so-a0-jf-b0-$(LINUX_FIRMWARE_IWL_AX210_UCODE_API_MAX_9560).ucode \
+	iwlwifi-so-a0-hr-b0-$(LINUX_FIRMWARE_IWL_AX210_UCODE_API_MAX).ucode \
+	iwlwifi-so-a0-gf-a0-$(LINUX_FIRMWARE_IWL_AX210_UCODE_API_MAX).ucode \
 	iwlwifi-so-a0-gf-a0.pnvm \
-	iwlwifi-ty-a0-gf-a0-$(LINUX_FIRMWARE_AX210_UCODE_API_MAX).ucode \
+	iwlwifi-ty-a0-gf-a0-$(LINUX_FIRMWARE_IWL_AX210_UCODE_API_MAX).ucode \
 	iwlwifi-ty-a0-gf-a0.pnvm
 LINUX_FIRMWARE_ALL_LICENSE_FILES += LICENCE.iwlwifi_firmware
 endif


### PR DESCRIPTION
Update to maximum version compatible with Linux 6.12 and still provided in linux-firmware 20240115.

Also, rename the constant for AX210 firmwares to better match the kernel symbol.