### PR TITLE
Update linux-firmware to 20240513 for Linux 6.12

### DIFF
--- a/package/linux-firmware/linux-firmware.hash
+++ b/package/linux-firmware/linux-firmware.hash
@@ -1,5 +1,5 @@
 # From https://mirrors.edge.kernel.org/pub/linux/kernel/firmware/sha256sums.asc
-sha256  ab7caff09bbb9e68e2b8a7c3e86d32b65f6444caa4ef8b0aabca9503da2c678d  linux-firmware-20240115.tar.xz
+sha256  9f05edb99668135d37cedc4fdd18aac2802dc9e4566e086e6c6c2e321f3ecc4e  linux-firmware-20240513.tar.xz
 
 # Hash for license files
 sha256  8116433f4004fc0c24d72b3d9e497808b724aa0e5e1cd63fc1bf66b715b1e2e9  LICENCE.Abilis
@@ -38,6 +38,6 @@ sha256  8542aeabf2761935122d693561e16766ce1bcc2b0d003204f9040b7d6d929f2e  LICENS
 sha256  be904cd28cb292b80cdb6cf412ab0d9159d431671e987ad433c1f62e0988a9bc  LICENSE.qcom
 sha256  fc6223d4bfe9f2f9e2eddc44b9fe5721d0caf49f01cb08d602906add686d8c6f  LICENSE.radeon
 sha256  2bdd2e716f05d9737d3f9a20f9a3a3c0caee0e866100ddb0673f1178e42f92b9  LICENSE.sdma_firmware
-sha256  92d477fe15d81875bc5bcc4c54df7e95b65f42e4c44d64d840f39cd0aa153d6f  WHENCE
+sha256  09453d13d522ce48c11fd37a04bc4a46b88792bc6e51c3b73cdcc5acb364e763  WHENCE
 sha256  fa43e1b9a13b341a07adca9dbe73d0f9072d7966fdfe811c01f0dd2872d7309a  qcom/NOTICE.txt
 sha256  bef9c828e84f21e7835b4de7daf954a327e1ff777871b58e116039b684c0d604  LICENCE.e100

--- a/package/linux-firmware/linux-firmware.mk
+++ b/package/linux-firmware/linux-firmware.mk
@@ -537,11 +537,12 @@ LINUX_FIRMWARE_IWL8000_UCODE_API_MAX = 36
 LINUX_FIRMWARE_IWL8265_UCODE_API_MAX = 36
 LINUX_FIRMWARE_IWL9000_UCODE_API_MAX = 46
 LINUX_FIRMWARE_IWL_22000_UCODE_API_MAX = 77
-LINUX_FIRMWARE_AX210_UCODE_API_MAX = 83
+LINUX_FIRMWARE_IWL_AX210_UCODE_API_MAX = 89
 # The 9560 driver has maximum ucode API defined in ax210.c yet its versions
 # are seemingly tracking the 22000 series.
-LINUX_FIRMWARE_AX210_UCODE_API_MAX_9560 = 77
-LINUX_FIRMWARE_IWL_BZ_UCODE_API_MAX = 83
+LINUX_FIRMWARE_IWL_AX210_UCODE_API_MAX_9560 = 77
+# Capped by linux-firmware, Linux 6.12 has max 93 (but min 90)
+LINUX_FIRMWARE_IWL_BZ_UCODE_API_MAX = 90
 
 ifeq ($(BR2_PACKAGE_LINUX_FIRMWARE_IWLWIFI_22000),y)
 LINUX_FIRMWARE_FILES += \
@@ -635,11 +636,11 @@ endif
 # it only has firmware only up to version 77, like other in 22000.
 ifeq ($(BR2_PACKAGE_LINUX_FIRMWARE_IWLWIFI_6E),y)
 LINUX_FIRMWARE_FILES += \
-	iwlwifi-so-a0-jf-b0-$(LINUX_FIRMWARE_AX210_UCODE_API_MAX_9560).ucode \
-	iwlwifi-so-a0-hr-b0-$(LINUX_FIRMWARE_AX210_UCODE_API_MAX).ucode \
-	iwlwifi-so-a0-gf-a0-$(LINUX_FIRMWARE_AX210_UCODE_API_MAX).ucode \
+	iwlwifi-so-a0-jf-b0-$(LINUX_FIRMWARE_IWL_AX210_UCODE_API_MAX_9560).ucode \
+	iwlwifi-so-a0-hr-b0-$(LINUX_FIRMWARE_IWL_AX210_UCODE_API_MAX).ucode \
+	iwlwifi-so-a0-gf-a0-$(LINUX_FIRMWARE_IWL_AX210_UCODE_API_MAX).ucode \
 	iwlwifi-so-a0-gf-a0.pnvm \
-	iwlwifi-ty-a0-gf-a0-$(LINUX_FIRMWARE_AX210_UCODE_API_MAX).ucode \
+	iwlwifi-ty-a0-gf-a0-$(LINUX_FIRMWARE_IWL_AX210_UCODE_API_MAX).ucode \
 	iwlwifi-ty-a0-gf-a0.pnvm
 LINUX_FIRMWARE_ALL_LICENSE_FILES += LICENCE.iwlwifi_firmware
 endif

--- a/package/linux-firmware/linux-firmware.mk
+++ b/package/linux-firmware/linux-firmware.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LINUX_FIRMWARE_VERSION = 20240115
+LINUX_FIRMWARE_VERSION = 20240513
 LINUX_FIRMWARE_SOURCE = linux-firmware-$(LINUX_FIRMWARE_VERSION).tar.xz
 LINUX_FIRMWARE_SITE = $(BR2_KERNEL_MIRROR)/linux/kernel/firmware
 LINUX_FIRMWARE_INSTALL_IMAGES = YES


### PR DESCRIPTION
This is the minimum version that adds new firmware versions for some Intel WiFi cards required by Linux 6.12, but introducing minimal bloat from `amdgpu` additions.