### PR TITLE
package/rpi-firmware: bump to 1.20250305 with updated firmware binaries

### DIFF
--- a/package/rpi-firmware/rpi-firmware.hash
+++ b/package/rpi-firmware/rpi-firmware.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256  9fecabe9ea6bed0e64e9c2cf37794ce1277933878460e374ea88c1b3b03b8eed  rpi-firmware-39a2813a75827b3a4d104a97e8f872df5d4f7e54.tar.gz
+sha256  83356a9091ccea6dc88a58299dbcdd23f530be6720a2f5d7546a9403df576812  rpi-firmware-f9ff9c8f22a148a555a2c090af9649ad84709dc4.tar.gz
 sha256  c7283ff51f863d93a275c66e3b4cb08021a5dd4d8c1e7acc47d872fbe52d3d6b  boot/LICENCE.broadcom

--- a/package/rpi-firmware/rpi-firmware.mk
+++ b/package/rpi-firmware/rpi-firmware.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_FIRMWARE_VERSION = 39a2813a75827b3a4d104a97e8f872df5d4f7e54
+RPI_FIRMWARE_VERSION = f9ff9c8f22a148a555a2c090af9649ad84709dc4
 RPI_FIRMWARE_SITE = $(call github,raspberrypi,firmware,$(RPI_FIRMWARE_VERSION))
 RPI_FIRMWARE_LICENSE = BSD-3-Clause
 RPI_FIRMWARE_LICENSE_FILES = boot/LICENCE.broadcom


### PR DESCRIPTION
Update to latest release, with kernel files unchanged, but with updated firmware (boot) binaries that fix issues with the latest EEPROM bootloader on Pi4.