### PR TITLE
package/linux-firmware: add firmware for Intel Ma models

### DIFF
--- a/package/linux-firmware/linux-firmware.mk
+++ b/package/linux-firmware/linux-firmware.mk
@@ -636,6 +636,8 @@ endif
 # it only has firmware only up to version 77, like other in 22000.
 ifeq ($(BR2_PACKAGE_LINUX_FIRMWARE_IWLWIFI_6E),y)
 LINUX_FIRMWARE_FILES += \
+	iwlwifi-ma-b0-gf-a0-$(LINUX_FIRMWARE_IWL_AX210_UCODE_API_MAX).ucode \
+	iwlwifi-ma-b0-gf-a0.pnvm \
 	iwlwifi-so-a0-jf-b0-$(LINUX_FIRMWARE_IWL_AX210_UCODE_API_MAX_9560).ucode \
 	iwlwifi-so-a0-hr-b0-$(LINUX_FIRMWARE_IWL_AX210_UCODE_API_MAX).ucode \
 	iwlwifi-so-a0-gf-a0-$(LINUX_FIRMWARE_IWL_AX210_UCODE_API_MAX).ucode \


### PR DESCRIPTION
Add firmware and PNVM file for Ma device types, reported to by used for example by AX211D2W (showing in the system as Intel(R) Wi-Fi 6E AX211 160MHz).