### PR TITLE
package/pigz: install unpigz as well

### DIFF
--- a/package/pigz/pigz.mk
+++ b/package/pigz/pigz.mk
@@ -22,10 +22,12 @@ endef
 
 define PIGZ_INSTALL_TARGET_CMDS
 	$(INSTALL) -D -m 0755 $(@D)/pigz $(TARGET_DIR)/usr/bin/pigz
+	ln -sf pigz $(TARGET_DIR)/usr/bin/unpigz
 endef
 
 define HOST_PIGZ_INSTALL_CMDS
 	$(INSTALL) -D -m 0755 $(@D)/pigz $(HOST_DIR)/bin/pigz
+	ln -sf pigz $(HOST_DIR)/usr/bin/unpigz
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
The pigz binary can also be used as unpigz which decompresses without extra -d argument. Create a symlink for it.