### PR TITLE
Bump Docker to 28.3.0

### DIFF
--- a/package/docker-cli/docker-cli.hash
+++ b/package/docker-cli/docker-cli.hash
@@ -1,3 +1,3 @@
 # Locally calculated
-sha256  09b41aa5ff656bc135feb80cb9b73c70aeba099ef9756c3cef7bcb2eb3c98ba6  docker-cli-28.0.4-go2.tar.gz
+sha256  0ac18927138cd2582e02277d365174a118b962f10084a6bef500a58de705e094  docker-cli-28.3.0-go2.tar.gz
 sha256  2d81ea060825006fc8f3fe28aa5dc0ffeb80faf325b612c955229157b8c10dc0  LICENSE

--- a/package/docker-cli/docker-cli.mk
+++ b/package/docker-cli/docker-cli.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-DOCKER_CLI_VERSION = 28.0.4
+DOCKER_CLI_VERSION = 28.3.0
 DOCKER_CLI_SITE = $(call github,docker,cli,v$(DOCKER_CLI_VERSION))
 
 DOCKER_CLI_LICENSE = Apache-2.0

--- a/package/docker-engine/docker-engine.hash
+++ b/package/docker-engine/docker-engine.hash
@@ -1,3 +1,3 @@
 # Locally calculated
-sha256  4b347a2b83221952cab93197f6e9bc7ffe54dd4bd0a9644c176aecde551721ca  docker-engine-28.0.4-go2.tar.gz
+sha256  99fe19d2a15d3cc56b9bd5e782664a85c2a7027566a4acc5c07ec8d42666362b  docker-engine-28.3.0-go2.tar.gz
 sha256  7c87873291f289713ac5df48b1f2010eb6963752bbd6b530416ab99fc37914a8  LICENSE

--- a/package/docker-engine/docker-engine.mk
+++ b/package/docker-engine/docker-engine.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-DOCKER_ENGINE_VERSION = 28.0.4
+DOCKER_ENGINE_VERSION = 28.3.0
 DOCKER_ENGINE_SITE = $(call github,moby,moby,v$(DOCKER_ENGINE_VERSION))
 
 DOCKER_ENGINE_LICENSE = Apache-2.0


### PR DESCRIPTION
Release notes:
* https://docs.docker.com/engine/release-notes/28/#2830