### PR TITLE
package/containerd: bump version to v2.2.1

### DIFF
--- a/package/containerd/containerd.hash
+++ b/package/containerd/containerd.hash
@@ -1,3 +1,3 @@
 # Computed locally
-sha256  86e7a268fc73f5332522baef86082c1d6c17986e2957a9ad842ead35d1080fca  containerd-2.2.0-go2.tar.gz
+sha256  af5707a26891486332142cc0ade4f0c543f707d3954838f5cecee73b833cf9b4  containerd-2.2.1-go2.tar.gz
 sha256  4bbe3b885e8cd1907ab4cf9a41e862e74e24b5422297a4f2fe524e6a30ada2b4  LICENSE

--- a/package/containerd/containerd.mk
+++ b/package/containerd/containerd.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-CONTAINERD_VERSION = 2.2.0
+CONTAINERD_VERSION = 2.2.1
 CONTAINERD_SITE = $(call github,containerd,containerd,v$(CONTAINERD_VERSION))
 CONTAINERD_LICENSE = Apache-2.0
 CONTAINERD_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Changelog:
* https://github.com/containerd/containerd/releases/tag/v2.2.1