### PR TITLE
package/rpi-firmware: update to eb3ee43 (for 6.12.75)

### DIFF
--- a/package/rpi-firmware/rpi-firmware.hash
+++ b/package/rpi-firmware/rpi-firmware.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256  391af5d8cac347c50961b2807fb2dcc8936eaf16b1e45c1528b3dc1a729a5e52  rpi-firmware-ba22330437d0aaae38ee01dc333e3210536a8333.tar.gz
+sha256  c9480b7cd231074faafdef5aef55ae6faced2c98ed7f192317bb7d25640a25ed  rpi-firmware-eb3ee430dd1c96a9415c4be3657d8f0e976f8102.tar.gz
 sha256  c7283ff51f863d93a275c66e3b4cb08021a5dd4d8c1e7acc47d872fbe52d3d6b  boot/LICENCE.broadcom

--- a/package/rpi-firmware/rpi-firmware.mk
+++ b/package/rpi-firmware/rpi-firmware.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 # Please keep in sync with configs/raspberrypi*_deconfig
-RPI_FIRMWARE_VERSION = ba22330437d0aaae38ee01dc333e3210536a8333
+RPI_FIRMWARE_VERSION = eb3ee430dd1c96a9415c4be3657d8f0e976f8102
 RPI_FIRMWARE_SITE = $(call github,raspberrypi,firmware,$(RPI_FIRMWARE_VERSION))
 RPI_FIRMWARE_LICENSE = BSD-3-Clause
 RPI_FIRMWARE_LICENSE_FILES = boot/LICENCE.broadcom


### PR DESCRIPTION
Update to version with git_hash matching the 6.12.75 APT release.