### PR TITLE
package/linux-firmware: add RTL8125D rev.b firmware

### DIFF
--- a/package/linux-firmware/linux-firmware.mk
+++ b/package/linux-firmware/linux-firmware.mk
@@ -805,6 +805,7 @@ LINUX_FIRMWARE_FILES += \
 	rtl_nic/rtl8125a-3.fw \
 	rtl_nic/rtl8125b-2.fw \
 	rtl_nic/rtl8125d-1.fw \
+	rtl_nic/rtl8125d-2.fw \
 	rtl_nic/rtl8168d-1.fw \
 	rtl_nic/rtl8168d-2.fw \
 	rtl_nic/rtl8168e-1.fw \


### PR DESCRIPTION
Add firmware for RTL8125D rev.b added in [1]. The r8169 driver currently supports this card since Linux 6.14. The firmware was added in [2] included in linux-firmware since version 20250109.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=b3593df26ab19f114d613693fa8a92ab202803d0
[2] https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/commit/?id=163296523cd4ccebbbd9026a769c76901c3a8e83