### PR TITLE
package/linux-firmware: add WiFi and BT firmware for MT7920

### DIFF
--- a/package/linux-firmware/Config.in
+++ b/package/linux-firmware/Config.in
@@ -94,6 +94,11 @@ config BR2_PACKAGE_LINUX_FIRMWARE_MEDIATEK_MT7650
 	help
 	  Firmware files for MediaTek MT7650 bluetooth support
 
+config BR2_PACKAGE_LINUX_FIRMWARE_MEDIATEK_MT7920_BT
+	bool "MediaTek MT7920"
+	help
+	  Firmware files for MediaTek MT7920 bluetooth support
+
 config BR2_PACKAGE_LINUX_FIRMWARE_MEDIATEK_MT7921_BT
 	bool "MediaTek MT7921"
 	help
@@ -481,6 +486,11 @@ config BR2_PACKAGE_LINUX_FIRMWARE_MEDIATEK_MT76X2E
 	bool "MediaTek MT76x2e"
 	help
 	  MediaTek MT76x2e
+
+config BR2_PACKAGE_LINUX_FIRMWARE_MEDIATEK_MT7920
+	bool "MediaTek MT7920"
+	help
+	  MediaTek MT7920
 
 config BR2_PACKAGE_LINUX_FIRMWARE_MEDIATEK_MT7921
 	bool "MediaTek MT7921"

--- a/package/linux-firmware/linux-firmware.mk
+++ b/package/linux-firmware/linux-firmware.mk
@@ -398,6 +398,19 @@ LINUX_FIRMWARE_FILES += mediatek/mt7662.bin mediatek/mt7662_rom_patch.bin
 LINUX_FIRMWARE_ALL_LICENSE_FILES += LICENCE.ralink_a_mediatek_company_firmware
 endif
 
+# MT7920
+ifeq ($(BR2_PACKAGE_LINUX_FIRMWARE_MEDIATEK_MT7920),y)
+LINUX_FIRMWARE_FILES += mediatek/WIFI_MT7961_patch_mcu_1a_2_hdr.bin \
+			mediatek/WIFI_RAM_CODE_MT7961_1a.bin
+LINUX_FIRMWARE_ALL_LICENSE_FILES += LICENCE.mediatek
+endif
+
+# Mediatek MT7920 Bluetooth
+ifeq ($(BR2_PACKAGE_LINUX_FIRMWARE_MEDIATEK_MT7920_BT),y)
+LINUX_FIRMWARE_FILES += mediatek/BT_RAM_CODE_MT7961_1a_2_hdr.bin
+LINUX_FIRMWARE_ALL_LICENSE_FILES += LICENCE.mediatek
+endif
+
 # MT7921
 ifeq ($(BR2_PACKAGE_LINUX_FIRMWARE_MEDIATEK_MT7921),y)
 LINUX_FIRMWARE_FILES += mediatek/WIFI_MT7961_patch_mcu_1_2_hdr.bin \


### PR DESCRIPTION
Add firmware for the MediaTek MT7920 chip, which is handled by the mt7921e driver. WiFi support was added in Linux 6.10 [1] and Bluetooth support in Linux 6.9 [2]. The firmware files were added in [3] (WiFi) and [4] (BT), included in linux-firmware since version 20241017.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=4a40fcbfe3ab4846670b59b81c914ed7e7dac2b3
[2] https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=1cb63d80fff6c4f501469e28a0eb6379639e0711
[3] https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/commit/?id=3ce84a8dbf4a418cc982503596e481a1be84eab1
[4] https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/commit/?id=7f9c1f1b1c0edd237c2d0b72fbc15e74be624b77