### PR TITLE
package/linux-firmware: add Intel Bz WiFi firmware

### DIFF
--- a/package/linux-firmware/Config.in
+++ b/package/linux-firmware/Config.in
@@ -377,6 +377,12 @@ config BR2_PACKAGE_LINUX_FIRMWARE_IWLWIFI_7
 	  Firmware files for the Intel Wi-Fi 7 (BE20x) devices
 	  supported by the iwlwifi kernel driver.
 
+config BR2_PACKAGE_LINUX_FIRMWARE_IWLWIFI_BZ
+	bool "Intel iwlwifi Bz"
+	help
+	  Firmware files for the Intel Wi-Fi 7 devices of the Bz
+	  family (e.g. BE201) supported by the iwlwifi kernel driver.
+
 config BR2_PACKAGE_LINUX_FIRMWARE_IWLWIFI_QUZ
 	bool "Intel iwlwifi QuZ"
 	help

--- a/package/linux-firmware/linux-firmware.mk
+++ b/package/linux-firmware/linux-firmware.mk
@@ -726,6 +726,13 @@ LINUX_FIRMWARE_FILES += intel/iwlwifi/iwlwifi-gl-c0-fm-c0*.{ucode,pnvm}
 LINUX_FIRMWARE_ALL_LICENSE_FILES += LICENCE.iwlwifi_firmware
 endif
 
+ifeq ($(BR2_PACKAGE_LINUX_FIRMWARE_IWLWIFI_BZ),y)
+LINUX_FIRMWARE_FILES += \
+	intel/iwlwifi/iwlwifi-bz-b0-fm-c0-$(LINUX_FIRMWARE_IWL_BZ_UCODE_API_MAX).ucode \
+	intel/iwlwifi/iwlwifi-bz-b0-fm-c0.pnvm
+LINUX_FIRMWARE_ALL_LICENSE_FILES += LICENCE.iwlwifi_firmware
+endif
+
 ifeq ($(BR2_PACKAGE_LINUX_FIRMWARE_IWLWIFI_QUZ),y)
 LINUX_FIRMWARE_FILES += intel/iwlwifi/iwlwifi-QuZ-*.ucode
 LINUX_FIRMWARE_ALL_LICENSE_FILES += LICENCE.iwlwifi_firmware


### PR DESCRIPTION
The Intel Wi-Fi 7 Bz family (e.g. BE201, PCI 8086:7740) uses the iwlwifi-bz-* firmware, which is distinct from the gl-* firmware shipped by the existing IWLWIFI_7/IWLWIFI_GL options. Add a dedicated IWLWIFI_BZ option installing iwlwifi-bz-b0-fm-c0 so these devices are functional.

The firmware files are present in linux-firmware since 20250701.